### PR TITLE
[test] include time.h for bsd build

### DIFF
--- a/tests/helpers.h
+++ b/tests/helpers.h
@@ -125,6 +125,8 @@ typename NearestNeighbourSearch<T>::Matrix createQuery(const typename NearestNei
 #ifdef __MACH__
 #include <mach/clock.h>
 #include <mach/mach.h>
+#else
+#include <time.h>
 #endif
 
 #ifdef _POSIX_TIMERS 


### PR DESCRIPTION
`CLOCK_PROCESS_CPUTIME_ID` is defined in `<time.h>`
- http://pubs.opengroup.org/onlinepubs/009695299/basedefs/time.h.html

Here is the error on NetBSD-6.1.2-x86_64:

```
In file included from /local/robotpkg/var/tmp/robotpkg/wip/libnabo/work/libnabo-1.0.4/tests/knnbucketsize.cpp:33:0:
/local/robotpkg/var/tmp/robotpkg/wip/libnabo/work/libnabo-1.0.4/tests/helpers.h: In member function 'boost::timer::Time boost::timer::curTime() const':
/local/robotpkg/var/tmp/robotpkg/wip/libnabo/work/libnabo-1.0.4/tests/helpers.h:158:18: error: 'CLOCK_PROCESS_CPUTIME_ID' was not declared in this scope
In file included from /local/robotpkg/var/tmp/robotpkg/wip/libnabo/work/libnabo-1.0.4/tests/knnbench.cpp:37:0:
/local/robotpkg/var/tmp/robotpkg/wip/libnabo/work/libnabo-1.0.4/tests/helpers.h: In member function 'boost::timer::Time boost::timer::curTime() const':
/local/robotpkg/var/tmp/robotpkg/wip/libnabo/work/libnabo-1.0.4/tests/helpers.h:158:18: error: 'CLOCK_PROCESS_CPUTIME_ID' was not declared in this scope
```
