### PR TITLE
[test] use CLOCK_PROF for NetBSD build

### DIFF
--- a/tests/helpers.h
+++ b/tests/helpers.h
@@ -155,7 +155,11 @@ namespace boost
 			mach_port_deallocate(mach_task_self(), cclock);
 			#else
 			struct timespec ts;
+			#ifdef CLOCK_PROCESS_CPUTIME_ID
 			clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts);
+			#else // BSD and old Linux
+			clock_gettime(CLOCK_PROF, &ts);
+			#endif
 			#endif
 			return Time(ts.tv_sec) * Time(1000000000) + Time(ts.tv_nsec);
 		}


### PR DESCRIPTION
This time it builds fine: http://robotpkg.openrobots.org/rbulk/robotpkg-wip/wip/libnabo
It might need some test though. The same patch apply to `libpointmatcher`.

_cf._ http://www.freebsd.org/cgi/man.cgi?query=clock_gettime
