### PR TITLE
Fix UBSAN error calculating maxNodeCount

### DIFF
--- a/nabo/kdtree_cpu.cpp
+++ b/nabo/kdtree_cpu.cpp
@@ -242,7 +242,7 @@ namespace Nabo
 			return;
 		}
 		
-		const uint64_t maxNodeCount((1 << (32-dimBitCount)) - 1);
+		const uint64_t maxNodeCount((0x1ULL << (32-dimBitCount)) - 1);
 		const uint64_t estimatedNodeCount(cloud.cols() / (bucketSize / 2));
 		if (estimatedNodeCount > maxNodeCount)
 		{


### PR DESCRIPTION
- should use an explicitly uint64 constant
- simplest is to use ULL suffix
  (LLU is apparently standards compliant but not always supported)
- this came up because the nabor R package wrapping libnabo threw a UBSAN error
  for points with dimension = 1
- closes https://github.com/ethz-asl/libnabo/issues/16
