### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package libnabo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.1.1 (2024-03-19)
+------------------
 
 * Update README.md
 * Set minimum required CMake version to 3.10.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,52 @@
 Changelog for package libnabo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+
+* Update README.md
+* Set minimum required CMake version to 3.10.2
+* (origin/dev-feat-integrate-norlab-build-system-library-and-implement-linabo-build-system-NMO-405) style: renamed `.*test_compilation.*` services and target to `.*integration_test.*` for clarity.
+* doc(readme): mute ubuntu jammy from supported OS version until libpointmatcher build pass on jammy
+* ci: drop ubuntu jammy from build matrix
+* doc: add missing norlab light logo
+* doc: add missing norlab light logo
+* doc: update header with dynamic logo, fix hyperlink, add dockerhub badge and fix relative link
+* doc(pull_request_template.md): fix typo
+* doc(readme): add norlab logo to header and improve intro
+* test: add release crawler script bats test
+* build: add release crawler script and .env file
+* doc(readme): update header
+* build: update repo version format
+* doc: clean pr comment
+* feat: integrate norlab-build-system library and implement linabo-build-system [NMO-405]
+* build: Added norlab-shell-script-tools submodule to repository [NMO-405]
+* build: Added norlab-build-system submodule to repository [NMO-405]
+* chore: added a code owner designation file, a pull request template and a conventional commit reference file
+* Update README.md
+* Update README.md with cmake guide
+* Use CMakePackageConfigHelpers to generate config files. Fill libnabo_INCLUDE_DIRS and libnabo_LIBRARIES variables.
+* Fix Cmake Syntax invoked by Nabo's version regex. Updated min cmake version to 3.8
+* more robust extraction of version
+* Remove dependency on grep + Improve findstr command
+* Use findstr instead of grep on Windows
+* Date range and catch-all for authors
+* Upgrade all syntax to package format 3
+* format "3" specifier for condition flag
+* Keep catkin for ROS1
+* Create LICENSE file based on BSD license as per package.xml
+* catkin not required for pure cmake packages
+* Added link to Rust version.
+* Replace TABS with SPACES
+* Automaticaly find eigen3
+* Fix install-space include directories
+* fix missing eigen headers in python module
+* add complete cmake exported-targets usage example
+* option to disable doxygen; cmake clean up
+* better handling of STATIC build option
+* modernize cmake to have exported targets
+* Make library git submodule-friendly
+
 1.0.7 (2019-02-07)
 ------------------
 * Disabled cmake compile tests by default and on compilers that do not support them (#95)

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
 	<name>libnabo</name>
-	<version>1.0.7</version>
+	<version>1.1.1</version>
 	<description>
 		libnabo is a fast K Nearest Neighbour library for low-dimensional spaces.
 	</description>


### PR DESCRIPTION
# Description

Do a release of 1.1.1 for libnabo

### Summary:

The source release of 1.1.0 was done on this repository without bumping the package.xml version.  This means that that version cannot be released on the ROS 2 buildfarm to fix https://build.ros2.org/view/Rbin_uN64/job/Rsrc_uN__libnabo__ubuntu_noble__source/ .

Instead of moving the tag or any other git shenanigans, just make a new release 1.1.1 that properly updates the CHANGELOG and bumps the package.xml.  Once this is merged in, I'll need one of the maintainers to also create a tag (1.1.1), at which point we can `bloom-release` this and fix the build on the ROS 2 buildfarm.

### Changes and type of changes (quick overview):

- 1.1.1 release

---

# Checklist:

### Code related

- [N/A] I have made corresponding changes to the documentation 
      (i.e.: function, class, script header, README.md)
- [N/A] I have commented hard-to-understand code
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] All tests pass locally with my changes 
      (Check [contributing/contributing_instructions.md](/contributing/contributing_instructions.md) for local testing procedure using _libnabo-build-system_)


### PR creation related

- [ ] My pull request `base ref` branch is set to the `develop` branch 
     (the _build-system_ won't be triggered otherwise)
- [ ] My pull request branch is up-to-date with the `develop` branch 
     (the _build-system_ will reject it otherwise)

### PR description related

- [ ] I have included a quick summary of the changes
- [ ] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`
- [ ] I have included a high-level list of changes and their corresponding types
      (See [contributing/commit_msg_reference.md](/contributing/commit_msg_reference.md) for details)

---
