### PR TITLE
Add a GitHub action to upload API documentation to a webpage

### DIFF
--- a/.github/workflows/update_documentation.yaml
+++ b/.github/workflows/update_documentation.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main  # Modify this to match your main branch name
+  
+  workflow_dispatch:  # Allow manual triggering
 
 jobs:
   build:

--- a/.github/workflows/update_documentation.yaml
+++ b/.github/workflows/update_documentation.yaml
@@ -13,7 +13,7 @@ on:
       - published
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update_documentation.yaml
+++ b/.github/workflows/update_documentation.yaml
@@ -13,7 +13,7 @@ on:
       - published
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -32,8 +32,25 @@ jobs:
           cmake ..
           make doc
 
-      - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
         with:
-          folder: ./build/doc
-          branch: gh-pages
+          source: ./build/doc
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/update_documentation.yaml
+++ b/.github/workflows/update_documentation.yaml
@@ -33,13 +33,7 @@ jobs:
           make doc
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build/doc/html  # Directory containing the HTML documentation
-          if: ${{ github.event.release.tag_name }}
-          destination_dir: ./releases/${{ github.event.release.tag_name }}
-          keep_files: false
-          commit_message: Release ${{ github.event.release.tag_name }}
-
-
+          folder: ./build/doc
+          branch: gh-pages

--- a/.github/workflows/update_documentation.yaml
+++ b/.github/workflows/update_documentation.yaml
@@ -48,6 +48,10 @@ jobs:
     environment:
       name: github-pages
       url: ${{steps.deployment.outputs.page_url}}
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/update_documentation.yaml
+++ b/.github/workflows/update_documentation.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
-          source: ./build/doc
+          source: ./build/doc/html
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2

--- a/.github/workflows/update_documentation.yaml
+++ b/.github/workflows/update_documentation.yaml
@@ -3,7 +3,8 @@ name: Generate and Deploy Doxygen Documentation
 on:
   push:
     branches:
-      - main  # Modify this to match your main branch name
+      - master
+      - github-action-api-docs  # Modify this to match your master branch name
   
   workflow_dispatch:  # Allow manual triggering
 

--- a/.github/workflows/update_documentation.yaml
+++ b/.github/workflows/update_documentation.yaml
@@ -1,0 +1,33 @@
+name: Generate and Deploy Doxygen Documentation
+
+on:
+  push:
+    branches:
+      - main  # Modify this to match your main branch name
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake doxygen graphviz libboost-all-dev libeigen3-dev
+
+      - name: Configure and Build Project
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make doc
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/doc/html  # Directory containing the HTML documentation
+

--- a/.github/workflows/update_documentation.yaml
+++ b/.github/workflows/update_documentation.yaml
@@ -4,13 +4,8 @@ on:
   push:
     branches:
       - master
-      - github-action-api-docs  # Modify this to match your master branch name
   
   workflow_dispatch:  # Allow manual triggering
-
-  release:
-    types:
-      - published
 
 jobs:
   build:

--- a/.github/workflows/update_documentation.yaml
+++ b/.github/workflows/update_documentation.yaml
@@ -8,6 +8,10 @@ on:
   
   workflow_dispatch:  # Allow manual triggering
 
+  release:
+    types:
+      - published
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,4 +37,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/doc/html  # Directory containing the HTML documentation
+          if: ${{ github.event.release.tag_name }}
+          destination_dir: ./releases/${{ github.event.release.tag_name }}
+          keep_files: false
+          commit_message: Release ${{ github.event.release.tag_name }}
+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,17 @@ project("lib${LIB_NAME}")
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 
-# Extract version from header
-file(READ "nabo/nabo.h" NABO_HEADER_CONTENT)
-string(REGEX MATCH "#define NABO_VERSION \"([0-9]+\.[0-9]+\.[0-9]+)\"" _ ${NABO_HEADER_CONTENT})
-set(PROJECT_VERSION ${CMAKE_MATCH_1})
-message(STATUS ${PROJECT_VERSION})
+## Extract version from package.xml
+file(READ "package.xml" PACKAGE_XML_CONTENT)
+string(REGEX MATCH "<version>([^<]+)</version>" VERSION_MATCH ${PACKAGE_XML_CONTENT})
+# Extract the matched version from the captured group
+if(VERSION_MATCH)
+    # CMake variable ${CMAKE_MATCH_1} contains the matched version
+    set(PROJECT_VERSION ${CMAKE_MATCH_1})
+    message(STATUS "Found package version: ${PROJECT_VERSION}")
+else()
+    message(WARNING "Package version not found in package.xml")
+endif()
 
 if (NOT CMAKE_BUILD_TYPE)
 	message("-- No build type specified; defaulting to CMAKE_BUILD_TYPE=Release.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(VERSION_MATCH)
     set(PROJECT_VERSION ${CMAKE_MATCH_1})
     message(STATUS "Found package version: ${PROJECT_VERSION}")
 else()
-    message(WARNING "Package version not found in package.xml")
+    message(SEND_ERROR "Package version not found in package.xml")
 endif()
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ libnabo provides the following compilation options, available through [CMake]:
 
 ### Documentation
 
-You can generate the documentation by typing:
-
-	make doc
-
+You can access on https://norlab-ulaval.github.io/libnabo/. Alternatively, you can generate it locally by typing:
+```bash
+make doc
+```
 Prerequisites
 -------------
 

--- a/nabo/nabo.h
+++ b/nabo/nabo.h
@@ -205,6 +205,12 @@ libnabo differs from \ref ANN on the following points:
 namespace Nabo
 {
 	//! \defgroup public public interface
+	//@{
+
+	//! version of the Nabo library as string
+	#define NABO_VERSION "1.1.1"
+	//! version of the Nabo library as an int
+	#define NABO_VERSION_INT 10101
 
 	// TODO (c++14) Convert invalidIndex, invalidValue to constexpr templated variables.
 	template <typename IndexType>

--- a/nabo/nabo.h
+++ b/nabo/nabo.h
@@ -204,13 +204,7 @@ libnabo differs from \ref ANN on the following points:
 //! Namespace for Nabo
 namespace Nabo
 {
-	//! \defgroup public public interface 
-	//@{
-	
-	//! version of the Nabo library as string
-	#define NABO_VERSION "1.0.7"
-	//! version of the Nabo library as an int
-	#define NABO_VERSION_INT 10007
+	//! \defgroup public public interface
 
 	// TODO (c++14) Convert invalidIndex, invalidValue to constexpr templated variables.
 	template <typename IndexType>


### PR DESCRIPTION
# Description

### Summary:

### Changes and type of changes (quick overview):
Add a GitHub action to upload API documentation to a webpage.
The webpage is already live on https://norlab-ulaval.github.io/libnabo/ and will be updated automatically on merge to master.
