### PR TITLE
Add missing include

### DIFF
--- a/nabo/kdtree_cpu.cpp
+++ b/nabo/kdtree_cpu.cpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "nabo_private.h"
 #include "index_heap.h"
+#include <cassert>
 #include <iostream>
 #include <stdexcept>
 #include <limits>


### PR DESCRIPTION
# Description

### Summary:

`assert` is used in `kdtree_cpu.cpp` but `<cassert>` is not included directly.
It seems to be included through [Eigen/Core](https://gitlab.com/libeigen/eigen/-/blob/3.4/Eigen/Core?ref_type=heads#L84), but this does not appear to be the case in the latest [file](https://gitlab.com/libeigen/eigen/-/blob/f5ead2d34c19653b92ff6a5660f83c04f09a973a/Eigen/Core), which causes the build to fail.

### Changes and type of changes (quick overview):

- Include `<cassert>`

---

# Checklist:

### Code related

- [ ] I have made corresponding changes to the documentation 
      (i.e.: function, class, script header, README.md)
- [ ] I have commented hard-to-understand code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes 
      (Check [contributing/contributing_instructions.md](/contributing/contributing_instructions.md) for local testing procedure using _libnabo-build-system_)


### PR creation related

- [x] My pull request `base ref` branch is set to the `develop` branch 
     (the _build-system_ won't be triggered otherwise)
- [x] My pull request branch is up-to-date with the `develop` branch 
     (the _build-system_ will reject it otherwise)

### PR description related

- [x] I have included a quick summary of the changes
- [ ] I have indicated the related issue's id with `# <issue-id>` if changes are of type `fix`
- [ ] I have included a high-level list of changes and their corresponding types
      (See [contributing/commit_msg_reference.md](/contributing/commit_msg_reference.md) for details)

---
